### PR TITLE
protractor: lower timeout

### DIFF
--- a/test/protractor-conf.js
+++ b/test/protractor-conf.js
@@ -1,7 +1,7 @@
 'use strict';
 
 exports.config = {
-    allScriptsTimeout: 11000,
+    allScriptsTimeout: 300,
 
     specs: [
         'e2e/*.js'


### PR DESCRIPTION
We don't need a large timeout normally. When something is very wrong
with the setup, we'll want the tests to timeout sooner rather than
later anyway.