### PR TITLE
Handle empty listings

### DIFF
--- a/app/css/app.css
+++ b/app/css/app.css
@@ -28,6 +28,11 @@ td.icon {
     vertical-align: middle !important;
 }
 
+td.empty {
+    text-align: center;
+    font-style: italic;
+}
+
 div.upload {
     width: 12em;
     margin-bottom: 0px;

--- a/app/js/controllers.js
+++ b/app/js/controllers.js
@@ -56,6 +56,7 @@ var mod = angular.module('swiftBrowser.controllers', [
 ]);
 
 mod.controller('RootCtrl', function ($scope, $swift, $modal) {
+    $scope.finishedLoading = false;
     $scope.containers = [];
     $scope.updateOrderBy = mkUpdateOrderBy($scope);
     $scope.updateOrderBy('name');
@@ -112,6 +113,7 @@ mod.controller('RootCtrl', function ($scope, $swift, $modal) {
 
     $swift.listContainers().then(function (result) {
         $scope.containers = result.data;
+        $scope.finishedLoading = true;
     });
 });
 

--- a/app/partials/container.html
+++ b/app/partials/container.html
@@ -42,4 +42,7 @@
       </span></i>
     </td>
   </tr>
+  <tr ng-show="finishedLoading && items.length == 0">
+    <td colspan="3" class="empty">No objects.</td>
+  </tr>
 </table>

--- a/app/partials/root.html
+++ b/app/partials/root.html
@@ -36,7 +36,7 @@
     <td class="text-right" sb-format-bytes count="container.bytes"></td>
     <td class="text-right">{{ container.count | number }} objects</td>
   </tr>
-  <tr ng-hide="containers | notUndefined | length">
+  <tr ng-hide="finishedLoading">
     <td colspan="4">
       <i>Loading<span class="loading">
         <span>.</span>
@@ -44,5 +44,8 @@
         <span>.</span>
       </span></i>
     </td>
+  </tr>
+  <tr ng-show="finishedLoading && containers.length == 0">
+    <td colspan="4" class="empty">No containers.</td>
   </tr>
 </table>

--- a/test/e2e/scenarios.js
+++ b/test/e2e/scenarios.js
@@ -213,6 +213,24 @@ describe('Container listing', function () {
 
 
 describe('Object listing', function () {
+    describe('should show empty indicator', function () {
+        it('when there are no objects', function () {
+            SwiftMock.addContainer('foo');
+            browser.get('index.html#/foo/');
+            expect($('td.empty').isDisplayed()).toBe(true);
+        });
+
+        it('unless there are containers', function () {
+            SwiftMock.setObjects('foo', {
+                'x.txt': {headers: {
+                    'Content-Length': 20,
+                }},
+            });
+            browser.get('index.html#/foo/');
+            expect($('td.empty').isDisplayed()).toBe(false);
+        });
+    });
+
     describe('should be sortable', function () {
         beforeEach(function () {
             SwiftMock.setObjects('foo', {

--- a/test/e2e/scenarios.js
+++ b/test/e2e/scenarios.js
@@ -25,6 +25,19 @@ function uploadFile(path) {
 }
 
 describe('Container listing', function () {
+    describe('should show empty indicator', function () {
+        it('when there are no containers', function () {
+            browser.get('index.html#/');
+            expect($('td.empty').isDisplayed()).toBe(true);
+        });
+
+        it('unless there are containers', function () {
+            SwiftMock.addContainer('foo');
+            browser.get('index.html#/');
+            expect($('td.empty').isDisplayed()).toBe(false);
+        });
+    });
+
     describe('should be sortable', function () {
         beforeEach(function () {
             SwiftMock.setObjects('foo', {


### PR DESCRIPTION
This adds "No containers" and "No objects" texts to the listings where there are no containers and objects, respectively.